### PR TITLE
update spock, and groovy testing plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,8 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.10.1'
     id 'nebula.release' version '6.3.5'
     id "com.bmuschko.clover" version "2.2.3"
+    id "groovy"
 }
-
-// Apply the groovy plugin to add support for Groovy
-apply plugin: 'groovy'
 
 group = 'io.gitlab.grabl'
 
@@ -32,15 +30,16 @@ repositories {
 }
 
 dependencies {
+
     clover 'org.openclover:clover:4.3.1'
 
-    // Use the awesome Spock testing and specification framework
-    testCompile('org.spockframework:spock-core:1.1-groovy-2.4-rc-4') {
-        exclude module: 'groovy-all'
-    }
-    testCompile 'junit:junit:4.12'
-    // required by spock for mocking classes
-    testCompile 'net.bytebuddy:byte-buddy:1.9.12'
+    testCompile(
+        'junit:junit:4.12',
+        'org.codehaus.groovy:groovy-all:2.5.7',
+        'org.spockframework:spock-core:1.3-groovy-2.5',
+        'net.bytebuddy:byte-buddy:1.9.12'
+    )
+    
 }
 
 


### PR DESCRIPTION
update test plugins

NOTE: still have a warning when using java 11.  will be fixed in groovy 3...but that is not officially released yet.